### PR TITLE
Fix linting errors by adding needed permissions

### DIFF
--- a/ESenseLib/app/src/main/AndroidManifest.xml
+++ b/ESenseLib/app/src/main/AndroidManifest.xml
@@ -1,6 +1,9 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="io.esense.esenselib">
 
+    <uses-permission android:name="android.permission.BLUETOOTH" />
+    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
+
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"


### PR DESCRIPTION
This Pull Request adds the needed permissions to the library manifest.
App and library manifests are automatically merged, so apps using this library don't need to specify those permissions themselves.