### PR TITLE
Remove unneeded values from manifest

### DIFF
--- a/ESenseLib/app/src/main/AndroidManifest.xml
+++ b/ESenseLib/app/src/main/AndroidManifest.xml
@@ -1,11 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="io.esense.esenselib">
 
-    <application
-        android:allowBackup="true"
-        android:icon="@mipmap/ic_launcher"
-        android:label="@string/app_name"
-        android:roundIcon="@mipmap/ic_launcher_round"
-        android:supportsRtl="true"
-        android:theme="@style/AppTheme" />
+    <application/>
 </manifest>


### PR DESCRIPTION
These values causes manifest merging to fail.
The android build system merges manifests from apps and libraries. These values being present in the library manifest causes merging to fail if the app manifest also contains them, which it will with very high probability.